### PR TITLE
chore(ci): add GitHub Actions workflow

### DIFF
--- a/.github/workflows/pull_request.tests.yml
+++ b/.github/workflows/pull_request.tests.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 Preferred Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read # Needed to check out the repo.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# NOTE: We use simple job names because these are used in branch rulesets and
+#       are matched by name. This makes the job names an identifier rather than
+#       just a human-readable label.
+
+jobs:
+  tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: run tests
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ coverage.*
 profile.cov
 
 # Build artifacts
-build/tools
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,177 @@
+# Copyright 2026 Preferred Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+
 IMAGE=ghcr.io/pfnet/ns-reloader
 VERSION=$(shell git rev-parse HEAD)$(shell git diff --shortstat --exit-code --quiet || echo -dirty)
+
+uname_s := $(shell uname -s)
+uname_m := $(shell uname -m)
+arch.x86_64 := amd64
+arch.arm64 := arm64
+arch.aarch64 := arm64
+arch := $(arch.$(uname_m))
+kernel.Linux := linux
+kernel.Darwin := darwin
+kernel := $(kernel.$(uname_s))
+
+LOCALBIN ?= $(shell pwd)/build/tools
+
+## Tool Binaries
+ENVTEST_BINARY ?= $(LOCALBIN)/envtest
+GCI_BINARY ?= $(LOCALBIN)/gci
+GOLANGCI_LINT_BINARY = $(LOCALBIN)/golangci-lint
+GOIMPORTS_BINARY = $(LOCALBIN)/goimports
+
+## Tool Versions
+GCI_VERSION ?= v0.13.7
+# NOTE: Do not include the v prefix for golangci-lint
+GOLANGCI_LINT_VERSION ?= 2.7.2
+GOIMPORTS_VERSION ?= v0.40.0
 
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+.PHONY: all
+all: test build docker-build ## Run tests and build.
+
+.PHONY: build
+build: ## Build binary.
+	@go build -o build/ns-reloader .
+
+.PHONY: test
+test: lint unit-test ## Run tests.
+
+clean: ## Clean up build artifacts.
+	@$(RM) -f ns-reloader
+	@# NOTE: envtest creates files that are not writable.
+	@chmod -R +w build/
+	@$(RM) -rf build/
+
 ##@ Development
 
-.PHONY: all
-all: test build
+.PHONY: unit-test
+unit-test: envtest-install ## Run unit tests.
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST_BINARY) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./...
+
+.PHONY: lint
+lint: fmt-check vet golangci-lint ## Run all linters.
+
+.PHONY: golangci-lint
+golangci-lint: golangci-lint-install ## Run golangci-lint.
+	@$(GOLANGCI_LINT_BINARY) run
 
 .PHONY: fmt
-fmt: ## Run go fmt against code.
-	go fmt ./...
+fmt: goimports-install gci-install ## Format code.
+	@# Format code
+	@go fmt ./...
+	@# Remove unused imports 
+	@$(GOIMPORTS_BINARY) -l -w .
+	@# format imports by import type
+	@$(GCI_BINARY) write \
+		--skip-generated \
+		--skip-vendor \
+		-s standard \
+		-s default \
+		-s localmodule \
+		.
+
+.PHONY: fmt-check
+fmt-check: goimports-install gci-install ## Check code is formatted.
+	@unformatted="$$( \
+		( \
+			gofmt -l . && \
+			$(GOIMPORTS_BINARY) -l . && \
+			$(GCI_BINARY) list \
+				--skip-generated \
+				--skip-vendor \
+				-s standard \
+				-s default \
+				-s localmodule \
+				. \
+		) | sort -u \
+	)"; \
+	if [ -n "$${unformatted}" ]; then \
+		echo "The following files are not formatted. Please run 'make fmt'." >&2; \
+		echo "$${unformatted}" >&2; \
+		exit 1; \
+	fi;
 
 .PHONY: vet
 vet: ## Run go vet against code.
-	go vet ./...
-
-.PHONY: test
-test: envtest lint ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./...
-
-.PHONY: lint
-lint: fmt vet ## Run golangci-lint linter.
-	$(GOLANGCI_LINT) run
+	@go vet ./...
 
 ##@ Container Image
 
 PLATFORM ?= linux/amd64
-EXTRA_BUILD_ARGS ?= --load
+EXTRA_DOCKER_BUILD_ARGS ?= --load
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker buildx build --platform $(PLATFORM) -t $(IMAGE):$(VERSION) \
+	@docker buildx build \
+		--platform $(PLATFORM) \
+		-t $(IMAGE):$(VERSION) \
 		--build-arg BUILD_VERSION=$(VERSION) \
 		--build-arg BUILD_COMMIT=$(COMMIT) \
-		$(EXTRA_BUILD_ARGS) .
+		--output type=docker \
+		$(EXTRA_DOCKER_BUILD_ARGS) .
 
 ##@ Build Dependencies
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/build/tools
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
-## Tool Binaries
-GOLANGCI_LINT = golangci-lint
-ENVTEST ?= $(LOCALBIN)/envtest
+.PHONY: envtest-install
+envtest-install: $(ENVTEST_BINARY) ## Download envtest locally.
+$(ENVTEST_BINARY): $(LOCALBIN)
+	$(call go-install-tool,setup-envtest,$(ENVTEST_BINARY),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
 
-## Tool Versions
-ENVTEST_K8S_VERSION ?= 1.34.0
+.PHONY: golangci-lint-install
+golangci-lint-install: $(GOLANGCI_LINT_BINARY) ## Download golangci-lint locally.
+$(GOLANGCI_LINT_BINARY): $(LOCALBIN)
+	$(call install-release,golangci-lint,$(GOLANGCI_LINT_BINARY),"https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(kernel)-$(arch).tar.gz","golangci-lint-$(GOLANGCI_LINT_VERSION)-$(kernel)-$(arch)/golangci-lint","v$(GOLANGCI_LINT_VERSION)")
 
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest locally.
-$(ENVTEST): $(LOCALBIN)
-	$(call go-install-tool,setup-envtest,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
+.PHONY: gci-install
+gci-install: $(GCI_BINARY) ## Download gci locally.
+$(GCI_BINARY): $(LOCALBIN)
+	$(call go-install-tool,gci,$(GCI_BINARY),github.com/daixiang0/gci,${GCI_VERSION})
+
+.PHONY: goimports-install
+goimports-install: $(GOIMPORTS_BINARY) ## Download goimports locally.
+$(GOIMPORTS_BINARY): $(LOCALBIN)
+	$(call go-install-tool,goimports,$(GOIMPORTS_BINARY),golang.org/x/tools/cmd/goimports,${GOIMPORTS_VERSION})
+
+# $1 - tool name
+# $2 - target path with name of binary
+# $3 - release tarball url
+# $4 - path to binary inside the tarball
+# $5 - version tag
+define install-release
+@[ -f $(2) ] || { \
+set -euo pipefail; \
+temp_dir=$$(mktemp -d); \
+cd "$${temp_dir}"; \
+echo "Downloading $(1) $(5)"; \
+curl -sSLf -o release.tar.gz "$(3)"; \
+tar -xzf release.tar.gz; \
+mv "$${temp_dir}/$(4)" "$(2)"; \
+rm -rf "$${temp_dir}"; \
+}
+endef
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - tool name
@@ -65,12 +181,12 @@ $(ENVTEST): $(LOCALBIN)
 define go-install-tool
 @[ -f $(2) ] || { \
 set -e; \
-TMP_DIR=$$(mktemp -d); \
-cd $$TMP_DIR; \
+temp_dir=$$(mktemp -d); \
+cd "$${temp_dir}"; \
 go mod init tmp; \
 echo "Downloading $(1) $(4)"; \
-GOBIN=$$TMP_DIR go install $(3)@$(4); \
-mv $$TMP_DIR/$(1) $(2); \
-rm -rf $$TMP_DIR; \
+GOBIN="$${temp_dir}" go install $(3)@$(4); \
+mv "$${temp_dir}/$(1)" "$(2)"; \
+rm -rf "$${temp_dir}"; \
 }
 endef

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pfnet/ns-reloader
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
- Add GitHub Actions workflow for running tests on PRs.
- Greatly refactor Makefile.
  - Use specific version of golangci-lint and install locally.
  - Format with goimports (remove unnecessary imports), and gci (sort imports).