### PR TITLE
ci: add build args to release

### DIFF
--- a/.github/workflows/release.publish.yml
+++ b/.github/workflows/release.publish.yml
@@ -69,3 +69,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          build-args: |
+            BUILD_VERSION=${{ github.event.release.tag_name }}
+            BUILD_COMMIT=${{ github.sha }}


### PR DESCRIPTION
Adds build args to the release. These are built into the release binary in the release image.

Fixes #14
