### PR TITLE
fix: skip duplicate namespace updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ GCI_VERSION ?= v0.13.7
 # NOTE: Do not include the v prefix for golangci-lint
 GOLANGCI_LINT_VERSION ?= 2.7.2
 GOIMPORTS_VERSION ?= v0.40.0
+SETUP_ENVTEST_VERSION ?= v0.0.0-20260109145143-0c3a9102bc0a
 
 .PHONY: help
 help: ## Display this help.
@@ -138,7 +139,7 @@ $(LOCALBIN):
 .PHONY: envtest-install
 envtest-install: $(ENVTEST_BINARY) ## Download envtest locally.
 $(ENVTEST_BINARY): $(LOCALBIN)
-	$(call go-install-tool,setup-envtest,$(ENVTEST_BINARY),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
+	$(call go-install-tool,setup-envtest,$(ENVTEST_BINARY),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(SETUP_ENVTEST_VERSION))
 
 .PHONY: golangci-lint-install
 golangci-lint-install: $(GOLANGCI_LINT_BINARY) ## Download golangci-lint locally.

--- a/reloader.go
+++ b/reloader.go
@@ -157,10 +157,11 @@ func NewProcessManager(cfg *ProcessManagerConfig) *ProcessManager {
 
 // UpdateNamespaces updates the namespaces to watch and triggers a process
 // restart. This method may be called concurrently by Reconcile.
-func (pm *ProcessManager) UpdateNamespaces(ns []string) {
+func (pm *ProcessManager) UpdateNamespaces(ns string) {
 	// Update the requested namespaces to watch.
-	namespaces := strings.Join(ns, ",")
-	pm.watchNamespaces.Store(namespaces)
+	if pm.watchNamespaces.Swap(ns) == ns {
+		return
+	}
 	select {
 	case pm.updateChan <- struct{}{}:
 	default:
@@ -220,10 +221,13 @@ func (pm *ProcessManager) Start(ctx context.Context) error {
 				// since the last reload.
 				waitPeriod = max(pm.debouncePeriod-time.Since(lastReload), 0)
 			}
-			if !debounceTimer.Reset(waitPeriod) {
-				// The timer has already triggered. Create a new timer.
-				debounceTimer = time.NewTimer(waitPeriod)
+			if !debounceTimer.Stop() {
+				select {
+				case <-debounceTimer.C:
+				default:
+				}
 			}
+			debounceTimer.Reset(waitPeriod)
 			pm.log.Info("Namespace update received; scheduling restart", "waitPeriod", waitPeriod)
 		}
 	}
@@ -385,6 +389,6 @@ func (r *NamespaceWatcher) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 	sort.Strings(namespaces)
 
-	r.processManager.UpdateNamespaces(namespaces)
+	r.processManager.UpdateNamespaces(strings.Join(namespaces, ","))
 	return reconcile.Result{}, nil
 }

--- a/reloader.go
+++ b/reloader.go
@@ -221,7 +221,8 @@ func (pm *ProcessManager) Start(ctx context.Context) error {
 				// since the last reload.
 				waitPeriod = max(pm.debouncePeriod-time.Since(lastReload), 0)
 			}
-			debounceTimer.Reset(waitPeriod)
+			# We can ignore the previous timer completely.
+			_ = debounceTimer.Reset(waitPeriod)
 			pm.log.Info("Namespace update received; scheduling restart", "waitPeriod", waitPeriod)
 		}
 	}

--- a/reloader.go
+++ b/reloader.go
@@ -221,12 +221,6 @@ func (pm *ProcessManager) Start(ctx context.Context) error {
 				// since the last reload.
 				waitPeriod = max(pm.debouncePeriod-time.Since(lastReload), 0)
 			}
-			if !debounceTimer.Stop() {
-				select {
-				case <-debounceTimer.C:
-				default:
-				}
-			}
 			debounceTimer.Reset(waitPeriod)
 			pm.log.Info("Namespace update received; scheduling restart", "waitPeriod", waitPeriod)
 		}

--- a/reloader.go
+++ b/reloader.go
@@ -221,7 +221,7 @@ func (pm *ProcessManager) Start(ctx context.Context) error {
 				// since the last reload.
 				waitPeriod = max(pm.debouncePeriod-time.Since(lastReload), 0)
 			}
-			# We can ignore the previous timer completely.
+			// We can ignore the previous timer completely.
 			_ = debounceTimer.Reset(waitPeriod)
 			pm.log.Info("Namespace update received; scheduling restart", "waitPeriod", waitPeriod)
 		}

--- a/reloader_test.go
+++ b/reloader_test.go
@@ -119,7 +119,7 @@ func testProcessRestart(t *testing.T, orgName string, cmdArgs []string) {
 	}()
 
 	// Set the initial namespaces to trigger process start.
-	pm.UpdateNamespaces([]string{"initial-namespace"})
+	pm.UpdateNamespaces("initial-namespace")
 
 	// Wait for the initial process to start.
 	var oldPid int
@@ -206,7 +206,7 @@ func testDebounce(t *testing.T, orgName string, cmdArgs []string) {
 
 	// Set the initial namespaces to trigger process start.
 	startingNS := "initial-namespace"
-	pm.UpdateNamespaces([]string{startingNS})
+	pm.UpdateNamespaces(startingNS)
 
 	// Wait for the initial process to start.
 	var oldPid int
@@ -233,7 +233,7 @@ func testDebounce(t *testing.T, orgName string, cmdArgs []string) {
 	go func() {
 		// ~500 millisecond worth of updates
 		for i := range numUpdates {
-			pm.UpdateNamespaces([]string{fmt.Sprintf("namespace-%d", i)})
+			pm.UpdateNamespaces(fmt.Sprintf("namespace-%d", i))
 			time.Sleep(10 * time.Millisecond)
 		}
 	}()
@@ -253,6 +253,77 @@ func testDebounce(t *testing.T, orgName string, cmdArgs []string) {
 		}
 		return !failForever && storedWNS == expectedWNS
 	}, 5*time.Second, 500*time.Millisecond, "Timed out waiting for expected namespaces to be set")
+}
+
+func testTrailingDebounce(t *testing.T, orgName string, cmdArgs []string) {
+	pm := NewProcessManager(&ProcessManagerConfig{
+		kubeConfig:        nil,
+		namespaceSelector: fmt.Sprintf("organization/name=%s", orgName),
+		targetEnvVar:      defaultTargetEnvVar,
+
+		arguments:              cmdArgs,
+		terminationGracePeriod: 2 * time.Second,
+		sigkillTimeout:         2 * time.Second,
+		debouncePeriod:         200 * time.Millisecond,
+		logger:                 testr.New(t),
+	})
+
+	pmStop := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		assert.NoError(t, pm.Start(ctx))
+		close(pmStop)
+	}()
+	defer func() {
+		cancel()
+		<-pmStop
+	}()
+
+	pm.UpdateNamespaces("ns-0")
+	var oldPid int
+	require.Eventually(t, func() bool {
+		select {
+		case <-pm.Done():
+			return false
+		default:
+		}
+		oldPid = pm.currentPID()
+		return oldPid != 0
+	}, 5*time.Second, 50*time.Millisecond, "Timed out waiting initial process to start")
+	assert.Equal(t, oldPid, pm.currentPID(), "process restarted before the quiet period elapsed")
+	assert.Equal(t, "ns-0", os.Getenv(defaultTargetEnvVar), "namespaces changed before the quiet period elapsed")
+
+	var finalNS string
+	for i := range 5 {
+		finalNS = fmt.Sprintf("ns-%d", i+1)
+		pm.UpdateNamespaces(finalNS)
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Eventually(t, func() bool {
+		return pm.currentPID() != oldPid && os.Getenv(defaultTargetEnvVar) == finalNS
+	}, 5*time.Second, 50*time.Millisecond, "Timed out waiting for the final debounced restart")
+}
+
+func TestProcessManagerIgnoresDuplicateNamespaceUpdates(t *testing.T) {
+	pm := NewProcessManager(&ProcessManagerConfig{
+		targetEnvVar: defaultTargetEnvVar,
+		logger:       testr.New(t),
+	})
+
+	pm.UpdateNamespaces("ns-a")
+	select {
+	case <-pm.updateChan:
+	default:
+		t.Fatal("expected first namespace update to be queued")
+	}
+
+	pm.UpdateNamespaces("ns-a")
+	select {
+	case <-pm.updateChan:
+		t.Fatal("duplicate namespace update should not be queued")
+	default:
+	}
 }
 
 func TestReloader(t *testing.T) {
@@ -283,5 +354,10 @@ func TestProcessManager(t *testing.T) {
 	t.Run("handles debounce", func(t *testing.T) {
 		args := []string{"sh", "-c", "trap 'exit' TERM; while :; do sleep 1; done"}
 		testDebounce(t, "test-debounce", args)
+	})
+
+	t.Run("uses trailing-edge debounce", func(t *testing.T) {
+		args := []string{"sh", "-c", "trap 'exit' TERM; while :; do sleep 1; done"}
+		testTrailingDebounce(t, "test-trailing-debounce", args)
 	})
 }

--- a/reloader_test.go
+++ b/reloader_test.go
@@ -229,6 +229,39 @@ func testDebounce(t *testing.T, orgName string, cmdArgs []string) {
 	t.Log("Initial process started with PID", oldPid)
 
 	numUpdates := 50
+	expectedWNS := fmt.Sprintf("namespace-%d", numUpdates-1)
+	envHistory := make(chan string, numUpdates+1)
+	pidHistory := make(chan int, numUpdates+1)
+	observeDone := make(chan struct{})
+	go func() {
+		defer close(observeDone)
+
+		prevWNS := os.Getenv(defaultTargetEnvVar)
+		prevPID := pm.currentPID()
+		for {
+			curWNS := os.Getenv(defaultTargetEnvVar)
+			curPID := pm.currentPID()
+			if curWNS != prevWNS {
+				envHistory <- curWNS
+				prevWNS = curWNS
+			}
+			if curPID != 0 && curPID != prevPID {
+				pidHistory <- curPID
+				prevPID = curPID
+			}
+			if curWNS == expectedWNS && curPID != 0 && curPID != oldPid {
+				// We've observed the expected final state, we can stop observing now.
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}()
+
 	// Rapidly update namespaces.
 	go func() {
 		// ~500 millisecond worth of updates
@@ -238,71 +271,26 @@ func testDebounce(t *testing.T, orgName string, cmdArgs []string) {
 		}
 	}()
 
-	var failForever bool
-	assert.Eventually(t, func() bool {
-		storedWNS := os.Getenv(defaultTargetEnvVar)
-		expectedWNS := fmt.Sprintf("namespace-%d", numUpdates-1)
-		if storedWNS != startingNS && storedWNS != expectedWNS {
-			// We expect only the last update to be applied after debouncing.
-			// If we see any intermediate namespaces, fail the test.
-			// NOTE: because testify/assert.Eventually runs the condition
-			//       function in a goroutine, we cannot use t.FailNow() or
-			//       similar method to quit early.
-			t.Logf("Expected namespaces %q but got %q", expectedWNS, storedWNS)
-			failForever = true
-		}
-		return !failForever && storedWNS == expectedWNS
-	}, 5*time.Second, 500*time.Millisecond, "Timed out waiting for expected namespaces to be set")
-}
-
-func testTrailingDebounce(t *testing.T, orgName string, cmdArgs []string) {
-	pm := NewProcessManager(&ProcessManagerConfig{
-		kubeConfig:        nil,
-		namespaceSelector: fmt.Sprintf("organization/name=%s", orgName),
-		targetEnvVar:      defaultTargetEnvVar,
-
-		arguments:              cmdArgs,
-		terminationGracePeriod: 2 * time.Second,
-		sigkillTimeout:         2 * time.Second,
-		debouncePeriod:         200 * time.Millisecond,
-		logger:                 testr.New(t),
-	})
-
-	pmStop := make(chan struct{})
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	go func() {
-		assert.NoError(t, pm.Start(ctx))
-		close(pmStop)
-	}()
-	defer func() {
-		cancel()
-		<-pmStop
-	}()
-
-	pm.UpdateNamespaces("ns-0")
-	var oldPid int
-	require.Eventually(t, func() bool {
-		select {
-		case <-pm.Done():
-			return false
-		default:
-		}
-		oldPid = pm.currentPID()
-		return oldPid != 0
-	}, 5*time.Second, 50*time.Millisecond, "Timed out waiting initial process to start")
-	assert.Equal(t, oldPid, pm.currentPID(), "process restarted before the quiet period elapsed")
-	assert.Equal(t, "ns-0", os.Getenv(defaultTargetEnvVar), "namespaces changed before the quiet period elapsed")
-
-	var finalNS string
-	for i := range 5 {
-		finalNS = fmt.Sprintf("ns-%d", i+1)
-		pm.UpdateNamespaces(finalNS)
-		time.Sleep(100 * time.Millisecond)
+	select {
+	case <-observeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected to observe the expected final state within the timeout")
 	}
-	assert.Eventually(t, func() bool {
-		return pm.currentPID() != oldPid && os.Getenv(defaultTargetEnvVar) == finalNS
-	}, 5*time.Second, 50*time.Millisecond, "Timed out waiting for the final debounced restart")
+	close(envHistory)
+	close(pidHistory)
+
+	var transitions []string
+	for wns := range envHistory {
+		transitions = append(transitions, wns)
+	}
+	assert.Equal(t, []string{expectedWNS}, transitions, "expected only the final debounced namespace to be applied")
+
+	var pidTransitions []int
+	for pid := range pidHistory {
+		pidTransitions = append(pidTransitions, pid)
+	}
+	assert.Len(t, pidTransitions, 1, "expected exactly one debounced process restart")
+	assert.NotEqual(t, oldPid, pidTransitions[0], "expected the debounced restart to use a new PID")
 }
 
 func TestProcessManagerIgnoresDuplicateNamespaceUpdates(t *testing.T) {
@@ -354,10 +342,5 @@ func TestProcessManager(t *testing.T) {
 	t.Run("handles debounce", func(t *testing.T) {
 		args := []string{"sh", "-c", "trap 'exit' TERM; while :; do sleep 1; done"}
 		testDebounce(t, "test-debounce", args)
-	})
-
-	t.Run("uses trailing-edge debounce", func(t *testing.T) {
-		args := []string{"sh", "-c", "trap 'exit' TERM; while :; do sleep 1; done"}
-		testTrailingDebounce(t, "test-trailing-debounce", args)
 	})
 }


### PR DESCRIPTION
## why

The reloader could repeatedly show `Namespace update received; scheduling restart` logs even when namespace label events did not change the watched namespace set.

## Fix

https://github.com/pfnet/ns-reloader/issues/20
